### PR TITLE
add RPROMPT support

### DIFF
--- a/lib/hooks.zsh
+++ b/lib/hooks.zsh
@@ -45,7 +45,9 @@ spaceship_precmd_hook() {
 
   # Draw initial prompt (no async jobs started yet)
   PROMPT=$(spaceship::compose_prompt $SPACESHIP_PROMPT_ORDER)
+  RPROMPT=$(spaceship::compose_prompt $SPACESHIP_RPROMPT_ORDER)
 
   # Load all async sections
   spaceship::async_load_prompt $SPACESHIP_PROMPT_ORDER
+  spaceship::async_load_prompt $SPACESHIP_RPROMPT_ORDER
 }

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -139,15 +139,6 @@ spaceship::deprecated SPACESHIP_BATTERY_FULL_SYMBOL "Use %BSPACESHIP_BATTERY_SYM
 # An entry point of prompt
 # ------------------------------------------------------------------------------
 
-# $RPROMPT
-# Optional (right) prompt
-spaceship_rprompt() {
-  # Retrieve exit code of last command to use in exit_code
-  RETVAL=$?
-
-  spaceship::compose_prompt $SPACESHIP_RPROMPT_ORDER
-}
-
 # PS2
 # Continuation interactive prompt
 spaceship_ps2() {
@@ -176,6 +167,7 @@ spaceship_async_callback() {
 
   SPACESHIP_ASYNC_NEED_REDRAW_PROMPT=0
   PROMPT=$(spaceship::compose_prompt $SPACESHIP_PROMPT_ORDER)
+  RPROMPT=$(spaceship::compose_prompt $SPACESHIP_RPROMPT_ORDER)
   zle .reset-prompt
   zle -R
 }
@@ -209,7 +201,6 @@ prompt_spaceship_setup() {
 
   # Expose Spaceship to environment variables
   PS2='$(spaceship_ps2)'
-  RPS1='$(spaceship_rprompt)'
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
#### Description

This adds (initial) RPROMPT support and solves one of my problems discussed in #9. I only tested with the following `SPACESHIP_` settings, anything else might or might not work:

```zsh
SPACESHIP_PROMPT_ORDER=(
  # time          # Time stampts section
  user          # Username section
  dir           # Current directory section
  host          # Hostname section
  exec_time     # Execution time
  line_sep      # Line break
  jobs          # Background jobs indicator
  char          # Prompt character
)
SPACESHIP_RPROMPT_ORDER=(
  git_branch
  git_status
)
export SPACESHIP_CHAR_SYMBOL="❯ "
export SPACESHIP_JOBS_SYMBOL="»"
export SPACESHIP_USER_SHOW=always
export SPACESHIP_USER_PREFIX="as "
export SPACESHIP_HOST_SHOW=always
export SPACESHIP_EXEC_TIME_ELAPSED=1
export SPACESHIP_BATTERY_SHOW=false
export SPACESHIP_DIR_TRUNC=0
export SPACESHIP_DIR_TRUNC_REPO=0
```

#### Screenshot

Please, attach a screenshot, if possible.

![screenshot](https://i.imgur.com/Mf6ilE7.png)