### PR TITLE
Always make async worker change into current directory

### DIFF
--- a/lib/hooks.zsh
+++ b/lib/hooks.zsh
@@ -43,6 +43,9 @@ spaceship_precmd_hook() {
   [[ $SPACESHIP_PROMPT_ADD_NEWLINE == true && $SPACESHIP_PROMPT_NEED_NEWLINE == true ]] && echo -n "$NEWLINE"
   SPACESHIP_PROMPT_NEED_NEWLINE=true
 
+  # Switch async worker to the current directory
+  async_worker_eval spaceship "cd '$PWD'"
+
   # Draw initial prompt (no async jobs started yet)
   PROMPT=$(spaceship::compose_prompt $SPACESHIP_PROMPT_ORDER)
   RPROMPT=$(spaceship::compose_prompt $SPACESHIP_RPROMPT_ORDER)

--- a/sections/git_branch.zsh
+++ b/sections/git_branch.zsh
@@ -20,12 +20,10 @@ SPACESHIP_GIT_BRANCH_COLOR="${SPACESHIP_GIT_BRANCH_COLOR="magenta"}"
 spaceship_async_job_load_git_branch() {
   [[ $SPACESHIP_GIT_BRANCH_SHOW == false ]] && return
 
-  async_job spaceship spaceship_async_job_git_branch "$PWD"
+  async_job spaceship spaceship_async_job_git_branch
 }
 
 spaceship_async_job_git_branch() {
-  builtin cd -q "$1" 2>/dev/null
-
   zstyle ':vcs_info:*' enable git
   zstyle ':vcs_info:git*' formats '%b'
   zstyle ':vcs_info:git*' actionformats '%b|%a'

--- a/sections/git_status.zsh
+++ b/sections/git_status.zsh
@@ -35,12 +35,10 @@ SPACESHIP_GIT_STATUS_DIVERGED_COLOR="${SPACESHIP_GIT_STATUS_DIVERGED_COLOR="yell
 spaceship_async_job_load_git_status() {
   [[ $SPACESHIP_GIT_STATUS_SHOW == false ]] && return
 
-  async_job spaceship spaceship_async_job_git_status "$PWD"
+  async_job spaceship spaceship_async_job_git_status
 }
 
 spaceship_async_job_git_status() {
-  builtin cd -q "$1" 2>/dev/null
-
   spaceship::is_git || return
 
   local INDEX git_status=""

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -22,15 +22,13 @@ SPACESHIP_RUBY_COLOR="${SPACESHIP_RUBY_COLOR="red"}"
 spaceship_async_job_load_ruby() {
   [[ $SPACESHIP_RUBY_SHOW == false ]] && return
 
-  async_job spaceship spaceship_async_job_ruby $PWD
+  async_job spaceship spaceship_async_job_ruby
 }
 
 spaceship_async_job_ruby() {
-  builtin cd -q "$1" 2>/dev/null
-
   # Show versions only for Ruby-specific folders
   setopt extendedglob
-  test -f Gemfile || test -f Rakefile || test -f "(../)#.ruby-version" || test -n *.rb(#qN^/) || return
+  test -f Gemfile || test -f Rakefile || test -f (../)#.ruby-version || test -n *.rb(#qN^/) || return
 
   local ruby_version
   if spaceship::exists rvm; then

--- a/sections/rust.zsh
+++ b/sections/rust.zsh
@@ -22,12 +22,10 @@ SPACESHIP_RUST_COLOR="${SPACESHIP_RUST_COLOR="red"}"
 spaceship_async_job_load_rust() {
   [[ $SPACESHIP_RUST_SHOW == false ]] && return
 
-    async_job spaceship spaceship_async_job_rust $PWD
+    async_job spaceship spaceship_async_job_rust
 }
 
 spaceship_async_job_rust() {
-  builtin cd -q $1 2>/dev/null
-
   # If there are Rust-specific files in current directory
   setopt extendedglob
   [[ -f Cargo.toml || -n *.rs(#qN^/) ]] || return

--- a/sections/tox.zsh
+++ b/sections/tox.zsh
@@ -24,11 +24,10 @@ SPACESHIP_TOX_SYMBOL_OK="${SPACESHIP_TOX_SYMBOL_OK="\u2714 "}"
 spaceship_async_job_load_tox() {
   [[ $SPACESHIP_TOX_SHOW == false ]] && return
 
-  async_job spaceship spaceship_async_job_tox "$PWD"
+  async_job spaceship spaceship_async_job_tox
 }
 
 spaceship_async_job_tox() {
-  builtin cd -q "$1" 2>/dev/null
   setopt extendedglob
   test -f (../)#tox.ini || return
   tox -q >/dev/null 2>&1 && echo 'OK' || echo 'FAIL'


### PR DESCRIPTION
With the latest zsh-async it is no longer needed to care about current directory in every section, we can make the change on a global level.

@cyrinux, @cole-h, @coredump make sure to update your zsh-async.