### PR TITLE
Set PATH and extendedglob in async job, migrate node section

### DIFF
--- a/lib/hooks.zsh
+++ b/lib/hooks.zsh
@@ -28,6 +28,7 @@ spaceship_precmd_hook() {
   if [[ -z "$SPACESHIP_ASYNC_INITIALIZED" ]]; then
     async_start_worker spaceship -u -n
     async_register_callback spaceship spaceship_async_callback
+    async_worker_eval spaceship 'setopt extendedglob'
     typeset -g SPACESHIP_ASYNC_INITIALIZED=1
   fi
 
@@ -43,8 +44,9 @@ spaceship_precmd_hook() {
   [[ $SPACESHIP_PROMPT_ADD_NEWLINE == true && $SPACESHIP_PROMPT_NEED_NEWLINE == true ]] && echo -n "$NEWLINE"
   SPACESHIP_PROMPT_NEED_NEWLINE=true
 
-  # Switch async worker to the current directory
+  # Switch async worker to the current directory and set environment variables
   async_worker_eval spaceship "cd '$PWD'"
+  async_worker_eval spaceship "export PATH='$PATH'"
 
   # Draw initial prompt (no async jobs started yet)
   PROMPT=$(spaceship::compose_prompt $SPACESHIP_PROMPT_ORDER)

--- a/lib/section.zsh
+++ b/lib/section.zsh
@@ -35,12 +35,6 @@ spaceship::section() {
 # USAGE:
 #   spaceship::async_load_prompt [section...]
 spaceship::async_load_prompt() {
-  # Option EXTENDED_GLOB is set locally to force filename generation on
-  # argument to conditions, i.e. allow usage of explicit glob qualifier (#q).
-  # See the description of filename generation in
-  # http://zsh.sourceforge.net/Doc/Release/Conditional-Expressions.html
-  setopt EXTENDED_GLOB LOCAL_OPTIONS
-
   # Treat the first argument as list of prompt sections
   # Load sections asynchronously if they provide such API.
   for section in $@; do

--- a/sections/node.zsh
+++ b/sections/node.zsh
@@ -20,9 +20,13 @@ SPACESHIP_NODE_COLOR="${SPACESHIP_NODE_COLOR="green"}"
 # ------------------------------------------------------------------------------
 
 # Show current version of node, exception system.
-spaceship_node() {
+spaceship_async_job_load_node() {
   [[ $SPACESHIP_NODE_SHOW == false ]] && return
 
+  async_job spaceship spaceship_async_job_node
+}
+
+spaceship_async_job_node() {
   # Show NODE status only for JS-specific folders
   [[ -f package.json || -d node_modules || -n *.js(#qN^/) ]] || return
 
@@ -41,10 +45,15 @@ spaceship_node() {
   fi
 
   [[ $node_version == $SPACESHIP_NODE_DEFAULT_VERSION ]] && return
+  echo "$node_version"
+}
+
+spaceship_node() {
+  [[ -z "${SPACESHIP_ASYNC_RESULTS[spaceship_async_job_node]}" ]] && return
 
   spaceship::section \
     "$SPACESHIP_NODE_COLOR" \
     "$SPACESHIP_NODE_PREFIX" \
-    "${SPACESHIP_NODE_SYMBOL}${node_version}" \
+    "${SPACESHIP_NODE_SYMBOL}${SPACESHIP_ASYNC_RESULTS[spaceship_async_job_node]}" \
     "$SPACESHIP_NODE_SUFFIX"
 }

--- a/sections/ruby.zsh
+++ b/sections/ruby.zsh
@@ -27,7 +27,6 @@ spaceship_async_job_load_ruby() {
 
 spaceship_async_job_ruby() {
   # Show versions only for Ruby-specific folders
-  setopt extendedglob
   test -f Gemfile || test -f Rakefile || test -f (../)#.ruby-version || test -n *.rb(#qN^/) || return
 
   local ruby_version

--- a/sections/rust.zsh
+++ b/sections/rust.zsh
@@ -22,12 +22,11 @@ SPACESHIP_RUST_COLOR="${SPACESHIP_RUST_COLOR="red"}"
 spaceship_async_job_load_rust() {
   [[ $SPACESHIP_RUST_SHOW == false ]] && return
 
-    async_job spaceship spaceship_async_job_rust
+  async_job spaceship spaceship_async_job_rust
 }
 
 spaceship_async_job_rust() {
   # If there are Rust-specific files in current directory
-  setopt extendedglob
   [[ -f Cargo.toml || -n *.rs(#qN^/) ]] || return
 
   spaceship::exists rustc || return

--- a/sections/tox.zsh
+++ b/sections/tox.zsh
@@ -28,7 +28,6 @@ spaceship_async_job_load_tox() {
 }
 
 spaceship_async_job_tox() {
-  setopt extendedglob
   test -f (../)#tox.ini || return
   tox -q >/dev/null 2>&1 && echo 'OK' || echo 'FAIL'
 }


### PR DESCRIPTION
Some refactoring. 

@cyrinux, @cole-h, @coredump would be cool if you guys could test the affected modules (the ones you use), to confirm that they still work — I'm personally not using any of these...